### PR TITLE
fix: dim = 2 in fit_transform overwrites self.dim set in constructor

### DIFF
--- a/hnne/projector.py
+++ b/hnne/projector.py
@@ -150,7 +150,6 @@ class HNNE(BaseEstimator):
             self,
             X: np.ndarray,
             y: np.ndarray = None,
-            dim: int = 2,
             verbose: bool = False,
             skip_hierarchy_building_if_done: bool = True
     ):
@@ -189,13 +188,8 @@ class HNNE(BaseEstimator):
                 partition_labels
             ] = self.fit_only_hierarchy(X, verbose=verbose)
 
-        if dim is not None and dim != self.dim:
-            if verbose:
-                print(f'Overwriting the dimensions {self.dim} to the new value {dim}.')
-            self.dim = dim
-
         if verbose:
-            print(f'Projecting to {dim} dimensions...')
+            print(f'Projecting to {self.dim} dimensions...')
         [
             projection,
             projected_centroid_radii,


### PR DESCRIPTION
Dear authors,

I noticed that there is an error in your implementation:

```python3
from hnne import HNNE
import numpy as np

data = np.random.random(size=(1000, 256))

hnne = HNNE(dim=3)
projection = hnne.fit_transform(data)

print(projection.shape)
>>> (1000, 2)
```
This appears to happen because `HNNE.fit_transform()` accepts an argument `dim` which is set to `2` by default.
Consequently, `self.dim` is always set to `2` if you do not pass an explicit argument to the method. I think this leads to a lot of confusion, so I fixed this by removing this logic altogether.

Testing the above example after the proposed changes yields the correct size.

Cheers!
